### PR TITLE
Prepare for 0.1a.0 release

### DIFF
--- a/azure_monitor/setup.cfg
+++ b/azure_monitor/setup.cfg
@@ -27,8 +27,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api
-    opentelemetry-sdk
+    opentelemetry-api >= 0.1a.0
+    opentelemetry-sdk >= 0.1a.0
 
 [options.packages.find]
 where = src

--- a/azure_monitor/src/azure_monitor/version.py
+++ b/azure_monitor/src/azure_monitor/version.py
@@ -1,3 +1,3 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-__version__ = "0.1.dev0"
+__version__ = "0.1a.0"


### PR DESCRIPTION
This PR updates the version number to 0.1a.0. This updates the v0.1a.x branch only, we'll keep the 0.1.dev0 version on master.

For now, we need to manually create a GH release and manually push to PyPI. We should automate this before the next release.