### PR TITLE
Fix tests

### DIFF
--- a/azure_monitor/tests/test_base_exporter.py
+++ b/azure_monitor/tests/test_base_exporter.py
@@ -9,7 +9,6 @@ from azure_monitor.export import BaseExporter
 from azure_monitor.options import ExporterOptions
 from azure_monitor.protocol import Data, Envelope
 
-
 TEST_FOLDER = os.path.abspath(".test.exporter")
 
 

--- a/azure_monitor/tests/test_base_exporter.py
+++ b/azure_monitor/tests/test_base_exporter.py
@@ -48,7 +48,9 @@ class TestBaseExporter(unittest.TestCase):
         self.assertEqual(base.options.storage_max_size, 3)
         self.assertEqual(base.options.storage_retention_period, 4)
         self.assertEqual(base.options.timeout, 5)
-        self.assertEqual(base.options.storage_path, os.path.join(TEST_FOLDER, self.id()))
+        self.assertEqual(
+            base.options.storage_path, os.path.join(TEST_FOLDER, self.id())
+        )
 
     def test_constructor_wrong_options(self):
         """Test the constructor with wrong options."""

--- a/azure_monitor/tests/test_base_exporter.py
+++ b/azure_monitor/tests/test_base_exporter.py
@@ -12,10 +12,12 @@ from azure_monitor.protocol import Data, Envelope
 TEST_FOLDER = os.path.abspath(".test.exporter")
 
 
+# pylint: disable=invalid-name
 def setUpModule():
     os.makedirs(TEST_FOLDER)
 
 
+# pylint: disable=invalid-name
 def tearDownModule():
     shutil.rmtree(TEST_FOLDER)
 

--- a/azure_monitor/tests/test_base_exporter.py
+++ b/azure_monitor/tests/test_base_exporter.py
@@ -2,11 +2,23 @@
 # Licensed under the MIT License.
 
 import os
+import shutil
 import unittest
 
 from azure_monitor.export import BaseExporter
 from azure_monitor.options import ExporterOptions
 from azure_monitor.protocol import Data, Envelope
+
+
+TEST_FOLDER = os.path.abspath(".test.exporter")
+
+
+def setUpModule():
+    os.makedirs(TEST_FOLDER)
+
+
+def tearDownModule():
+    shutil.rmtree(TEST_FOLDER)
 
 
 # pylint: disable=W0212
@@ -23,7 +35,7 @@ class TestBaseExporter(unittest.TestCase):
             instrumentation_key="4321abcd-5678-4efa-8abc-1234567890ab",
             storage_maintenance_period=2,
             storage_max_size=3,
-            storage_path="testStoragePath",
+            storage_path=os.path.join(TEST_FOLDER, self.id()),
             storage_retention_period=4,
             timeout=5,
         )
@@ -36,7 +48,7 @@ class TestBaseExporter(unittest.TestCase):
         self.assertEqual(base.options.storage_max_size, 3)
         self.assertEqual(base.options.storage_retention_period, 4)
         self.assertEqual(base.options.timeout, 5)
-        self.assertEqual(base.options.storage_path, "testStoragePath")
+        self.assertEqual(base.options.storage_path, os.path.join(TEST_FOLDER, self.id()))
 
     def test_constructor_wrong_options(self):
         """Test the constructor with wrong options."""

--- a/azure_monitor/tests/test_storage.py
+++ b/azure_monitor/tests/test_storage.py
@@ -13,7 +13,7 @@ from azure_monitor.storage import (
     _seconds,
 )
 
-TEST_FOLDER = os.path.abspath(".test")
+TEST_FOLDER = os.path.abspath(".test.storage")
 
 
 # pylint: disable=invalid-name

--- a/azure_monitor/tests/trace/test_trace.py
+++ b/azure_monitor/tests/trace/test_trace.py
@@ -126,7 +126,7 @@ class TestAzureExporter(unittest.TestCase):
             post.return_value = None
             exporter._transmit_from_storage()
 
-    def test_transmission_request_exception(self):
+    def test_transmit_request_exception(self):
         exporter = AzureMonitorSpanExporter(
             storage_path=os.path.join(TEST_FOLDER, self.id())
         )
@@ -152,7 +152,7 @@ class TestAzureExporter(unittest.TestCase):
             exporter._transmit_from_storage()
         self.assertTrue(exporter.storage.get())
 
-    def test_transmission_response_exception(self):
+    def test_transmit_response_exception(self):
         exporter = AzureMonitorSpanExporter(
             storage_path=os.path.join(TEST_FOLDER, self.id())
         )
@@ -223,7 +223,7 @@ class TestAzureExporter(unittest.TestCase):
             exporter.storage.get().get()[0]["name"], "testEnvelope"
         )
 
-    def test_transmission_206_nothing_to_retry(self):
+    def test_transmission_206_no_retry(self):
         exporter = AzureMonitorSpanExporter(
             storage_path=os.path.join(TEST_FOLDER, self.id())
         )


### PR DESCRIPTION
1. In Windows, `os.rename` fails sometimes when the file name created in a test blob creates a full path that is too long (260 characters). Changing names of certain tests that hit this use case.
See [this](https://stackoverflow.com/questions/51618629/python-large-file-name-rename-error-win-error-3)

2. Remove "testStoragePath" and clean up folders after test suite.
