### PR TITLE
Adding docs config and requirements

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,14 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+build:
+  image: latest
+
+python:
+  version: 3.8
+  install:
+    - requirements: docs-requirements.txt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,8 +3,5 @@ flake8~=3.7
 isort~=4.3
 black>=19.3b0,==19.*
 mypy==0.740
-sphinx~=2.1
-sphinx-rtd-theme~=0.4
-sphinx-autodoc-typehints~=1.10.2
 pytest!=5.2.3
 pytest-cov>=2.8

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,4 +1,8 @@
 sphinx~=2.4
 sphinx-rtd-theme~=0.4
 sphinx-autodoc-typehints~=1.10.2
+# External
+opentelemetry-api
+opentelemetry-sdk
+psutil
 

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -2,7 +2,7 @@ sphinx~=2.4
 sphinx-rtd-theme~=0.4
 sphinx-autodoc-typehints~=1.10.2
 # External
-opentelemetry-api
-opentelemetry-sdk
-psutil
+opentelemetry-api>= 0.5b0
+opentelemetry-sdk>= 0.5b0
+psutil>= 5.6.3
 

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,0 +1,4 @@
+sphinx~=2.4
+sphinx-rtd-theme~=0.4
+sphinx-autodoc-typehints~=1.10.2
+

--- a/tox.ini
+++ b/tox.ini
@@ -57,6 +57,7 @@ commands =
 [testenv:docs]
 deps =
   -c dev-requirements.txt
+  -c docs-requirements.txt
   sphinx
   sphinx-rtd-theme
   sphinx-autodoc-typehints

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,6 @@ commands =
 
 [testenv:docs]
 deps =
-  -c dev-requirements.txt
   -c docs-requirements.txt
   sphinx
   sphinx-rtd-theme


### PR DESCRIPTION
Local docs deployed available here:
https://hectorhdzg-opentelemetry-azure-python.readthedocs.io/en/latest/index.html 