### PR TITLE
Implement max size logic for local storage

### DIFF
--- a/azure_monitor/src/azure_monitor/options.py
+++ b/azure_monitor/src/azure_monitor/options.py
@@ -50,7 +50,7 @@ class ExporterOptions(BaseObject):
         connection_string: str = None,
         instrumentation_key: str = None,
         storage_maintenance_period: int = 60,
-        storage_max_size: int = 100 * 1024 * 1024,
+        storage_max_size: int = 50 * 1024 * 1024,
         storage_path: str = None,
         storage_retention_period: int = 7 * 24 * 60 * 60,
         timeout: int = 10.0,  # networking timeout in seconds

--- a/azure_monitor/tests/test_storage.py
+++ b/azure_monitor/tests/test_storage.py
@@ -108,6 +108,48 @@ class TestLocalFileStorage(unittest.TestCase):
                 self.assertIsNone(stor.put(test_input, silent=True))
                 self.assertRaises(Exception, lambda: stor.put(test_input))
 
+    def test_put_max_size(self):
+        test_input = (1, 2, 3)
+        with LocalFileStorage(os.path.join(TEST_FOLDER, 'asd')) as stor:
+            size_mock = mock.Mock()
+            size_mock.return_value = False
+            stor._check_storage_size = size_mock
+            stor.put(test_input)
+            self.assertEqual(stor.get(), None)
+
+    def test_check_storage_size_full(self):
+        test_input = (1, 2, 3)
+        with LocalFileStorage(os.path.join(TEST_FOLDER, 'asd2'), 1) as stor:
+            stor.put(test_input)
+            self.assertFalse(stor._check_storage_size())
+
+    def test_check_storage_size_not_full(self):
+        test_input = (1, 2, 3)
+        with LocalFileStorage(os.path.join(TEST_FOLDER, 'asd3'), 1000) as stor:
+            stor.put(test_input)
+            self.assertTrue(stor._check_storage_size())
+
+    def test_check_storage_size_no_files(self):
+        with LocalFileStorage(os.path.join(TEST_FOLDER, 'asd3'), 1000) as stor:
+            self.assertTrue(stor._check_storage_size())
+
+    def test_check_storage_size_links(self):
+        test_input = (1, 2, 3)
+        with LocalFileStorage(os.path.join(TEST_FOLDER, 'asd4'), 1000) as stor:
+            stor.put(test_input)
+            with mock.patch('os.path.islink') as os_mock:
+                os_mock.return_value = True
+            self.assertTrue(stor._check_storage_size())
+
+    def test_check_storage_size_error(self):
+        test_input = (1, 2, 3)
+        with LocalFileStorage(os.path.join(TEST_FOLDER, 'asd5'), 1) as stor:
+            with mock.patch('os.path.getsize', side_effect=throw(OSError)):
+                stor.put(test_input)
+                with mock.patch('os.path.islink') as os_mock:
+                    os_mock.return_value = True
+                self.assertTrue(stor._check_storage_size())
+
     def test_maintanence_routine(self):
         with mock.patch("os.makedirs") as m:
             m.return_value = None


### PR DESCRIPTION
Previously, `storage_max_size` configuration in exporters did not do anything.
Implements this logic in `storage` to stop storing files in local storage once max size has been reached (may have some spillage if the envelope is actually larger than the remaining size).

Runs size check everytime a `put` is called in storage, instead of saving the size of the folder. Keeping state will require us to handle concurrency issues and also introduces complications when adding/deleting.

See [dot net](https://github.com/microsoft/ApplicationInsights-dotnet/blob/e2752df59499dd364469fff7487470a4117e32d7/BASE/src/ServerTelemetryChannel/Implementation/TransmissionStorage.cs#L18-L25) and [java](https://github.com/microsoft/ApplicationInsights-Java/blob/master/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/TransmissionFileSystemOutput.java#L140) implementations of this logic.