### PR TITLE
Handle status 439 - Too Many Requests over extended time

### DIFF
--- a/azure_monitor/setup.cfg
+++ b/azure_monitor/setup.cfg
@@ -27,8 +27,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.5b0
-    opentelemetry-sdk >= 0.5b0
+    opentelemetry-api >= 0.6b0
+    opentelemetry-sdk >= 0.6b0
     psutil >= 5.6.3
     requests ~= 2.0
 

--- a/azure_monitor/src/azure_monitor/export/__init__.py
+++ b/azure_monitor/src/azure_monitor/export/__init__.py
@@ -144,6 +144,7 @@ class BaseExporter:
                         for error in data["errors"]:
                             if error["statusCode"] in (
                                 429,  # Too Many Requests
+                                439,  # Too Many Requests over extended time
                                 500,  # Internal Server Error
                                 503,  # Service Unavailable
                             ):
@@ -172,6 +173,7 @@ class BaseExporter:
             if response.status_code in (
                 206,  # Partial Content
                 429,  # Too Many Requests
+                439,  # Too Many Requests over extended time
                 500,  # Internal Server Error
                 503,  # Service Unavailable
             ):

--- a/azure_monitor/src/azure_monitor/storage.py
+++ b/azure_monitor/src/azure_monitor/storage.py
@@ -122,6 +122,7 @@ class LocalFileStorage:
             if not silent:
                 raise
         try:
+            # pylint: disable=unused-variable
             for blob in self.gets():
                 pass
         except Exception:

--- a/azure_monitor/tests/metrics/test_metrics.py
+++ b/azure_monitor/tests/metrics/test_metrics.py
@@ -20,7 +20,7 @@ from azure_monitor.export.metrics import AzureMonitorMetricsExporter
 from azure_monitor.options import ExporterOptions
 from azure_monitor.protocol import Data, DataPoint, Envelope, MetricData
 
-TEST_FOLDER = os.path.abspath(".test.exporter.trace")
+TEST_FOLDER = os.path.abspath(".test")
 STORAGE_PATH = os.path.join(TEST_FOLDER)
 
 

--- a/azure_monitor/tests/test_base_exporter.py
+++ b/azure_monitor/tests/test_base_exporter.py
@@ -19,7 +19,7 @@ from azure_monitor.export import (
 from azure_monitor.options import ExporterOptions
 from azure_monitor.protocol import Data, Envelope
 
-TEST_FOLDER = os.path.abspath(".test.exporter.base")
+TEST_FOLDER = os.path.abspath(".test")
 STORAGE_PATH = os.path.join(TEST_FOLDER)
 
 

--- a/azure_monitor/tests/test_base_exporter.py
+++ b/azure_monitor/tests/test_base_exporter.py
@@ -191,7 +191,7 @@ class TestBaseExporter(unittest.TestCase):
             exporter._transmit_from_storage()
         self.assertTrue(exporter.storage.get())
 
-    def test_(self):
+    def test_transmission(self):
         exporter = BaseExporter(
             storage_path=os.path.join(TEST_FOLDER, self.id())
         )
@@ -315,6 +315,18 @@ class TestBaseExporter(unittest.TestCase):
             post.return_value = MockResponse(400, "{}")
             exporter._transmit_from_storage()
         self.assertEqual(len(os.listdir(exporter.storage.path)), 0)
+
+    def test_transmission_439(self):
+        exporter = BaseExporter(
+            storage_path=os.path.join(TEST_FOLDER, self.id())
+        )
+        envelopes_to_export = map(lambda x: x.to_dict(), tuple([Envelope()]))
+        exporter.storage.put(envelopes_to_export)
+        with mock.patch("requests.post") as post:
+            post.return_value = MockResponse(439, "{}")
+            exporter._transmit_from_storage()
+        self.assertIsNone(exporter.storage.get())
+        self.assertEqual(len(os.listdir(exporter.storage.path)), 1)
 
     def test_transmission_500(self):
         exporter = BaseExporter(

--- a/azure_monitor/tests/test_storage.py
+++ b/azure_monitor/tests/test_storage.py
@@ -13,7 +13,7 @@ from azure_monitor.storage import (
     _seconds,
 )
 
-TEST_FOLDER = os.path.abspath(".test.storage")
+TEST_FOLDER = os.path.abspath(".test")
 
 
 # pylint: disable=invalid-name

--- a/azure_monitor/tests/trace/test_trace.py
+++ b/azure_monitor/tests/trace/test_trace.py
@@ -18,7 +18,7 @@ from azure_monitor.export import ExportResult
 from azure_monitor.export.trace import AzureMonitorSpanExporter
 from azure_monitor.options import ExporterOptions
 
-TEST_FOLDER = os.path.abspath(".test.exporter.trace")
+TEST_FOLDER = os.path.abspath(".test")
 STORAGE_PATH = os.path.join(TEST_FOLDER)
 
 


### PR DESCRIPTION
Include in base exporter to handle status 439 - Too many requests over extended time.

The majority of the other AI SDKs handles it exactly like 429: failed retryable.

[JS](https://github.com/microsoft/ApplicationInsights-JS/blob/17ef50442f73fd02a758fbd74134933d92607ecf/legacy/JavaScript/JavaScriptSDK/Sender.ts#L566): Errors on 439
[Node](https://github.com/microsoft/ApplicationInsights-node.js/blob/369b91d7c4f25a17a55671c60394edd9d9baf325/Library/Sender.ts#L143): Same as 429
[Java](https://github.com/microsoft/ApplicationInsights-Java/blob/a4437aa0817797e9e19e0f4ed7156290c9b22644/core/src/main/java/com/microsoft/applicationinsights/internal/channel/common/ThrottlingHandler.java#L60): Same as 429
[Dot Net](https://github.com/microsoft/ApplicationInsights-dotnet/blob/7633ae849edc826a8547745b6bf9f3174715d4bd/BASE/docs/ServerTelemetryChannel%20error%20handling.md#throttlingtransmissionpolicy): Similar to 429