### PR TITLE
Fix timestamps in live metrics

### DIFF
--- a/azure_monitor/setup.cfg
+++ b/azure_monitor/setup.cfg
@@ -27,8 +27,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api >= 0.6b0
-    opentelemetry-sdk >= 0.6b0
+    opentelemetry-api ~= 0.6b0
+    opentelemetry-sdk ~= 0.6b0
     psutil >= 5.6.3
     requests ~= 2.0
 

--- a/azure_monitor/src/azure_monitor/sdk/auto_collection/live_metrics/sender.py
+++ b/azure_monitor/src/azure_monitor/sdk/auto_collection/live_metrics/sender.py
@@ -3,7 +3,6 @@
 #
 import json
 import logging
-import time
 
 import requests
 
@@ -41,9 +40,8 @@ class LiveMetricsSender:
                 headers={
                     "Expect": "100-continue",
                     "Content-Type": "application/json; charset=utf-8",
-                    # TODO: Fix issue with incorrect time
                     utils.LIVE_METRICS_TRANSMISSION_TIME_HEADER: str(
-                        round(time.time()) * 1000
+                        utils.calculate_ticks_since_epoch()
                     ),
                 },
             )

--- a/azure_monitor/src/azure_monitor/sdk/auto_collection/live_metrics/utils.py
+++ b/azure_monitor/src/azure_monitor/sdk/auto_collection/live_metrics/utils.py
@@ -29,4 +29,6 @@ def create_metric_envelope(instrumentation_key: str):
 
 
 def calculate_ticks_since_epoch():
-    return (datetime.utcnow() - datetime(1, 1, 1)).total_seconds() * 10000000
+    return round(
+        (datetime.utcnow() - datetime(1, 1, 1)).total_seconds() * 10000000
+        )

--- a/azure_monitor/src/azure_monitor/sdk/auto_collection/live_metrics/utils.py
+++ b/azure_monitor/src/azure_monitor/sdk/auto_collection/live_metrics/utils.py
@@ -31,4 +31,4 @@ def create_metric_envelope(instrumentation_key: str):
 def calculate_ticks_since_epoch():
     return round(
         (datetime.utcnow() - datetime(1, 1, 1)).total_seconds() * 10000000
-        )
+    )

--- a/azure_monitor/src/azure_monitor/sdk/auto_collection/live_metrics/utils.py
+++ b/azure_monitor/src/azure_monitor/sdk/auto_collection/live_metrics/utils.py
@@ -1,11 +1,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 #
-import time
 import uuid
 
 from azure_monitor.protocol import LiveMetricEnvelope
 from azure_monitor.utils import azure_monitor_context
+from datetime import datetime
 
 DEFAULT_LIVEMETRICS_ENDPOINT = "https://rt.services.visualstudio.com"
 LIVE_METRICS_SUBSCRIBED_HEADER = "x-ms-qps-subscribed"
@@ -22,8 +22,11 @@ def create_metric_envelope(instrumentation_key: str):
         machine_name=azure_monitor_context.get("ai.device.id"),
         metrics=None,
         stream_id=STREAM_ID,
-        # TODO: Fix issue with incorrect time
-        timestamp="/Date({0})/".format(str(int(time.time()) * 1000)),
+        timestamp="/Date({0})/".format(str(calculate_ticks_since_epoch())),
         version=azure_monitor_context.get("ai.internal.sdkVersion"),
     )
     return envelope
+
+
+def calculate_ticks_since_epoch():
+    return (datetime.utcnow() - datetime(1, 1, 1)).total_seconds() * 10000000

--- a/azure_monitor/src/azure_monitor/sdk/auto_collection/live_metrics/utils.py
+++ b/azure_monitor/src/azure_monitor/sdk/auto_collection/live_metrics/utils.py
@@ -2,10 +2,10 @@
 # Licensed under the MIT License.
 #
 import uuid
+from datetime import datetime
 
 from azure_monitor.protocol import LiveMetricEnvelope
 from azure_monitor.utils import azure_monitor_context
-from datetime import datetime
 
 DEFAULT_LIVEMETRICS_ENDPOINT = "https://rt.services.visualstudio.com"
 LIVE_METRICS_SUBSCRIBED_HEADER = "x-ms-qps-subscribed"


### PR DESCRIPTION
From the [specs](https://msazure.visualstudio.com/One/_git/Mgmt-AppInsights-LiveMetricsService?path=%2Fdocs%2Fsdk.api.md&version=GBmaster&_a=preview&anchor=x-ms-qps-transmission-time).