### PR TITLE
fix serializable bug in metrics exporter

### DIFF
--- a/azure_monitor/src/azure_monitor/export/metrics/__init__.py
+++ b/azure_monitor/src/azure_monitor/export/metrics/__init__.py
@@ -35,7 +35,12 @@ class AzureMonitorMetricsExporter(BaseExporter, MetricsExporter):
         self, metric_records: Sequence[MetricRecord]
     ) -> MetricsExportResult:
         envelopes = list(map(self._metric_to_envelope, metric_records))
-        envelopes = self._apply_telemetry_processors(envelopes)
+        envelopes = list(
+            map(
+                lambda x: x.to_dict(),
+                self._apply_telemetry_processors(envelopes),
+            )
+        )
         try:
             result = self._transmit(envelopes)
             if result == ExportResult.FAILED_RETRYABLE:

--- a/azure_monitor/tests/metrics/test_metrics.py
+++ b/azure_monitor/tests/metrics/test_metrics.py
@@ -107,7 +107,7 @@ class TestAzureMetricsExporter(unittest.TestCase):
             CounterAggregator(), self._test_labels, self._test_metric
         )
         exporter = self._exporter
-        mte.return_value = []
+        mte.return_value = Envelope()
         transmit.return_value = ExportResult.SUCCESS
         result = exporter.export([record])
         self.assertEqual(result, MetricsExportResult.SUCCESS)
@@ -124,7 +124,7 @@ class TestAzureMetricsExporter(unittest.TestCase):
         )
         exporter = self._exporter
         transmit.return_value = ExportResult.FAILED_RETRYABLE
-        mte.return_value = []
+        mte.return_value = Envelope()
         storage_mock = mock.Mock()
         exporter.storage.put = storage_mock
         result = exporter.export([record])
@@ -143,7 +143,7 @@ class TestAzureMetricsExporter(unittest.TestCase):
             CounterAggregator(), self._test_labels, self._test_metric
         )
         exporter = self._exporter
-        mte.return_value = []
+        mte.return_value = Envelope()
         transmit.side_effect = throw(Exception)
         result = exporter.export([record])
         self.assertEqual(result, MetricsExportResult.FAILURE)


### PR DESCRIPTION
Bug from v0.3b release for metrics exporter.

Addresses https://github.com/microsoft/opentelemetry-azure-monitor-python/issues/91