### PR TITLE
Remove dependency metrics from autocollection

### DIFF
--- a/azure_monitor/CHANGELOG.md
+++ b/azure_monitor/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Remove dependency metrics from auto-collection
+- ([#92](https://github.com/microsoft/opentelemetry-azure-monitor-python/pull/92))
+
 ## 0.3b.1
 Released 2020-05-21
 

--- a/azure_monitor/src/azure_monitor/sdk/auto_collection/__init__.py
+++ b/azure_monitor/src/azure_monitor/sdk/auto_collection/__init__.py
@@ -44,7 +44,4 @@ class AutoCollection:
     ):
         col_type = AutoCollectionType.STANDARD_METRICS
         self._performance_metrics = PerformanceMetrics(meter, labels, col_type)
-        self._dependency_metrics = DependencyMetrics(
-            meter, labels, span_processor
-        )
         self._request_metrics = RequestMetrics(meter, labels, span_processor)

--- a/azure_monitor/tests/auto_collection/test_auto_collection.py
+++ b/azure_monitor/tests/auto_collection/test_auto_collection.py
@@ -30,9 +30,6 @@ class TestAutoCollection(unittest.TestCase):
         "azure_monitor.sdk.auto_collection.PerformanceMetrics", autospec=True
     )
     @mock.patch(
-        "azure_monitor.sdk.auto_collection.DependencyMetrics", autospec=True
-    )
-    @mock.patch(
         "azure_monitor.sdk.auto_collection.RequestMetrics", autospec=True
     )
     def test_constructor(
@@ -46,11 +43,8 @@ class TestAutoCollection(unittest.TestCase):
             span_processor=self._span_processor,
         )
         self.assertEqual(mock_performance.called, True)
-        self.assertEqual(mock_dependencies.called, True)
         self.assertEqual(mock_requests.called, True)
         self.assertEqual(mock_performance.call_args[0][0], self._meter)
         self.assertEqual(mock_performance.call_args[0][1], self._test_labels)
-        self.assertEqual(mock_dependencies.call_args[0][0], self._meter)
-        self.assertEqual(mock_dependencies.call_args[0][1], self._test_labels)
         self.assertEqual(mock_requests.call_args[0][0], self._meter)
         self.assertEqual(mock_requests.call_args[0][1], self._test_labels)

--- a/azure_monitor/tests/auto_collection/test_auto_collection.py
+++ b/azure_monitor/tests/auto_collection/test_auto_collection.py
@@ -32,9 +32,7 @@ class TestAutoCollection(unittest.TestCase):
     @mock.patch(
         "azure_monitor.sdk.auto_collection.RequestMetrics", autospec=True
     )
-    def test_constructor(
-        self, mock_requests, mock_performance
-    ):
+    def test_constructor(self, mock_requests, mock_performance):
         """Test the constructor."""
 
         AutoCollection(

--- a/azure_monitor/tests/auto_collection/test_auto_collection.py
+++ b/azure_monitor/tests/auto_collection/test_auto_collection.py
@@ -33,7 +33,7 @@ class TestAutoCollection(unittest.TestCase):
         "azure_monitor.sdk.auto_collection.RequestMetrics", autospec=True
     )
     def test_constructor(
-        self, mock_performance, mock_dependencies, mock_requests
+        self, mock_requests, mock_performance
     ):
         """Test the constructor."""
 


### PR DESCRIPTION
Only live metrics collects dependency metrics