### PR TITLE
Transport + storage changes

### DIFF
--- a/azure_monitor/CHANGELOG.md
+++ b/azure_monitor/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## Unreleased
 
 - Remove dependency metrics from auto-collection
-- ([#92](https://github.com/microsoft/opentelemetry-azure-monitor-python/pull/92))
+  ([#92](https://github.com/microsoft/opentelemetry-azure-monitor-python/pull/92))
+- Change default local storage directory
+  ([#100](https://github.com/microsoft/opentelemetry-azure-monitor-python/pull/100))
 
 ## 0.3b.1
 Released 2020-05-21

--- a/azure_monitor/src/azure_monitor/export/__init__.py
+++ b/azure_monitor/src/azure_monitor/export/__init__.py
@@ -95,12 +95,12 @@ class BaseExporter:
             # give a few more seconds for blob lease operation
             # to reduce the chance of race (for perf consideration)
             if blob.lease(self.options.timeout + 5):
-                envelopes = blob.get()  # TODO: handle error
+                envelopes = blob.get()
                 result = self._transmit(envelopes)
                 if result == ExportResult.FAILED_RETRYABLE:
                     blob.lease(1)
                 else:
-                    blob.delete(silent=True)
+                    blob.delete()
 
     # pylint: disable=too-many-branches
     # pylint: disable=too-many-nested-blocks
@@ -122,8 +122,14 @@ class BaseExporter:
                     },
                     timeout=self.options.timeout,
                 )
+            except requests.Timeout:
+                logger.warning(
+                    'Request time out. Ingestion may be backed up. Retrying.')
+                return ExportResult.FAILED_RETRYABLE
             except Exception as ex:
-                logger.warning("Transient client side error: %s.", ex)
+                logger.warning(
+                    'Retrying due to transient client side error %s.', ex)
+                # client side error (retryable)
                 return ExportResult.FAILED_RETRYABLE
 
             text = "N/A"

--- a/azure_monitor/src/azure_monitor/export/__init__.py
+++ b/azure_monitor/src/azure_monitor/export/__init__.py
@@ -124,11 +124,13 @@ class BaseExporter:
                 )
             except requests.Timeout:
                 logger.warning(
-                    'Request time out. Ingestion may be backed up. Retrying.')
+                    "Request time out. Ingestion may be backed up. Retrying."
+                )
                 return ExportResult.FAILED_RETRYABLE
             except Exception as ex:
                 logger.warning(
-                    'Retrying due to transient client side error %s.', ex)
+                    "Retrying due to transient client side error %s.", ex
+                )
                 # client side error (retryable)
                 return ExportResult.FAILED_RETRYABLE
 

--- a/azure_monitor/src/azure_monitor/export/__init__.py
+++ b/azure_monitor/src/azure_monitor/export/__init__.py
@@ -104,6 +104,7 @@ class BaseExporter:
 
     # pylint: disable=too-many-branches
     # pylint: disable=too-many-nested-blocks
+    # pylint: disable=too-many-return-statements
     def _transmit(self, envelopes: typing.List[Envelope]) -> ExportResult:
         """
         Transmit the data envelopes to the ingestion service.

--- a/azure_monitor/src/azure_monitor/options.py
+++ b/azure_monitor/src/azure_monitor/options.py
@@ -3,6 +3,7 @@
 import os
 import re
 import sys
+import tempfile
 import typing
 
 from azure_monitor.protocol import BaseObject
@@ -102,10 +103,8 @@ class ExporterOptions(BaseObject):
         if self.storage_path is None:
             TEMPDIR_SUFFIX = self.instrumentation_key or ""
             self.storage_path = os.path.join(
-                    tempfile.gettempdir(),
-                    TEMPDIR_PREFIX + TEMPDIR_SUFFIX
-                )
-
+                tempfile.gettempdir(), TEMPDIR_PREFIX + TEMPDIR_SUFFIX
+            )
 
     def _validate_instrumentation_key(self) -> None:
         """Validates the instrumentation key used for Azure Monitor.

--- a/azure_monitor/src/azure_monitor/options.py
+++ b/azure_monitor/src/azure_monitor/options.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 import os
 import re
-import sys
 import tempfile
 import typing
 
@@ -101,9 +100,9 @@ class ExporterOptions(BaseObject):
 
         # storage path
         if self.storage_path is None:
-            TEMPDIR_SUFFIX = self.instrumentation_key or ""
+            temp_suffix = self.instrumentation_key or ""
             self.storage_path = os.path.join(
-                tempfile.gettempdir(), TEMPDIR_PREFIX + TEMPDIR_SUFFIX
+                tempfile.gettempdir(), temp_suffix + TEMPDIR_SUFFIX
             )
 
     def _validate_instrumentation_key(self) -> None:

--- a/azure_monitor/src/azure_monitor/options.py
+++ b/azure_monitor/src/azure_monitor/options.py
@@ -9,6 +9,7 @@ from azure_monitor.protocol import BaseObject
 
 INGESTION_ENDPOINT = "ingestionendpoint"
 INSTRUMENTATION_KEY = "instrumentationkey"
+TEMPDIR_PREFIX = "opentelemetry-python-"
 
 # Validate UUID format
 # Specs taken from https://tools.ietf.org/html/rfc4122
@@ -55,13 +56,6 @@ class ExporterOptions(BaseObject):
         storage_retention_period: int = 7 * 24 * 60 * 60,
         timeout: int = 10.0,  # networking timeout in seconds
     ) -> None:
-        if storage_path is None:
-            storage_path = os.path.join(
-                os.path.expanduser("~"),
-                ".opentelemetry",
-                ".azure",
-                os.path.basename(sys.argv[0]) or ".console",
-            )
         self.connection_string = connection_string
         self.instrumentation_key = instrumentation_key
         self.storage_maintenance_period = storage_maintenance_period
@@ -74,6 +68,7 @@ class ExporterOptions(BaseObject):
         self._validate_instrumentation_key()
 
     def _initialize(self) -> None:
+        # cs and ikey
         code_cs = parse_connection_string(self.connection_string)
         code_ikey = self.instrumentation_key
         env_cs = parse_connection_string(
@@ -102,6 +97,15 @@ class ExporterOptions(BaseObject):
             or "https://dc.services.visualstudio.com"
         )
         self.endpoint = endpoint + "/v2/track"
+
+        # storage path
+        if self.storage_path is None:
+            TEMPDIR_SUFFIX = self.instrumentation_key or ""
+            self.storage_path = os.path.join(
+                    tempfile.gettempdir(),
+                    TEMPDIR_PREFIX + TEMPDIR_SUFFIX
+                )
+
 
     def _validate_instrumentation_key(self) -> None:
         """Validates the instrumentation key used for Azure Monitor.

--- a/azure_monitor/src/azure_monitor/options.py
+++ b/azure_monitor/src/azure_monitor/options.py
@@ -102,7 +102,7 @@ class ExporterOptions(BaseObject):
         if self.storage_path is None:
             temp_suffix = self.instrumentation_key or ""
             self.storage_path = os.path.join(
-                tempfile.gettempdir(), temp_suffix + TEMPDIR_SUFFIX
+                tempfile.gettempdir(), TEMPDIR_PREFIX + temp_suffix
             )
 
     def _validate_instrumentation_key(self) -> None:

--- a/azure_monitor/tests/test_base_exporter.py
+++ b/azure_monitor/tests/test_base_exporter.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import requests
 import shutil
 import unittest
 from unittest import mock
@@ -164,6 +165,17 @@ class TestBaseExporter(unittest.TestCase):
         with mock.patch("requests.post") as post:
             post.return_value = None
             exporter._transmit_from_storage()
+
+    def test_transmit_request_timeout(self):
+        exporter = BaseExporter(
+            storage_path=os.path.join(TEST_FOLDER, self.id())
+        )
+        envelopes_to_export = map(lambda x: x.to_dict(), tuple([Envelope()]))
+        exporter.storage.put(envelopes_to_export)
+        with mock.patch("requests.post", throw(requests.Timeout)):
+            exporter._transmit_from_storage()
+        self.assertIsNone(exporter.storage.get())
+        self.assertEqual(len(os.listdir(exporter.storage.path)), 1)
 
     def test_transmit_request_exception(self):
         exporter = BaseExporter(

--- a/azure_monitor/tests/test_base_exporter.py
+++ b/azure_monitor/tests/test_base_exporter.py
@@ -3,11 +3,11 @@
 
 import json
 import os
-import requests
 import shutil
 import unittest
 from unittest import mock
 
+import requests
 from opentelemetry.sdk.metrics.export import MetricsExportResult
 from opentelemetry.sdk.trace.export import SpanExportResult
 

--- a/azure_monitor/tests/test_storage.py
+++ b/azure_monitor/tests/test_storage.py
@@ -32,6 +32,7 @@ def throw(exc_type, *args, **kwargs):
 
     return func
 
+
 # pylint: disable=no-self-use
 class TestLocalFileBlob(unittest.TestCase):
     def test_delete(self):

--- a/azure_monitor/tests/test_storage.py
+++ b/azure_monitor/tests/test_storage.py
@@ -36,39 +36,37 @@ def throw(exc_type, *args, **kwargs):
 class TestLocalFileBlob(unittest.TestCase):
     def test_delete(self):
         blob = LocalFileBlob(os.path.join(TEST_FOLDER, "foobar"))
-        blob.delete(silent=True)
-        self.assertRaises(Exception, blob.delete)
-        self.assertRaises(Exception, lambda: blob.delete(silent=False))
+        blob.delete()
+        blob.delete()
 
     def test_get(self):
         blob = LocalFileBlob(os.path.join(TEST_FOLDER, "foobar"))
-        self.assertIsNone(blob.get(silent=True))
-        self.assertRaises(Exception, blob.get)
-        self.assertRaises(Exception, lambda: blob.get(silent=False))
+        self.assertIsNone(blob.get())
+        blob.get()
 
     def test_put_error(self):
         blob = LocalFileBlob(os.path.join(TEST_FOLDER, "foobar"))
         with mock.patch("os.rename", side_effect=throw(Exception)):
-            self.assertRaises(Exception, lambda: blob.put([1, 2, 3]))
+            blob.put([1, 2, 3])
 
     def test_put_without_lease(self):
         blob = LocalFileBlob(os.path.join(TEST_FOLDER, "foobar.blob"))
         test_input = (1, 2, 3)
-        blob.delete(silent=True)
+        blob.delete()
         blob.put(test_input)
         self.assertEqual(blob.get(), test_input)
 
     def test_put_with_lease(self):
         blob = LocalFileBlob(os.path.join(TEST_FOLDER, "foobar.blob"))
         test_input = (1, 2, 3)
-        blob.delete(silent=True)
+        blob.delete()
         blob.put(test_input, lease_period=0.01)
         blob.lease(0.01)
         self.assertEqual(blob.get(), test_input)
 
     def test_lease_error(self):
         blob = LocalFileBlob(os.path.join(TEST_FOLDER, "foobar.blob"))
-        blob.delete(silent=True)
+        blob.delete()
         self.assertEqual(blob.lease(0.01), None)
 
 
@@ -105,8 +103,7 @@ class TestLocalFileStorage(unittest.TestCase):
         with LocalFileStorage(os.path.join(TEST_FOLDER, "bar")) as stor:
             self.assertEqual(stor.get().get(), test_input)
             with mock.patch("os.rename", side_effect=throw(Exception)):
-                self.assertIsNone(stor.put(test_input, silent=True))
-                self.assertRaises(Exception, lambda: stor.put(test_input))
+                self.assertIsNone(stor.put(test_input))
 
     def test_put_max_size(self):
         test_input = (1, 2, 3)
@@ -152,25 +149,16 @@ class TestLocalFileStorage(unittest.TestCase):
 
     def test_maintanence_routine(self):
         with mock.patch("os.makedirs") as m:
-            m.return_value = None
-            self.assertRaises(
-                Exception,
-                lambda: LocalFileStorage(os.path.join(TEST_FOLDER, "baz")),
-            )
+            with LocalFileStorage(os.path.join(TEST_FOLDER, "baz")) as stor:
+                m.return_value = None
         with mock.patch("os.makedirs", side_effect=throw(Exception)):
-            self.assertRaises(
-                Exception,
-                lambda: LocalFileStorage(os.path.join(TEST_FOLDER, "baz")),
-            )
+            stor = LocalFileStorage(os.path.join(TEST_FOLDER, "baz"))
+            stor.close()
         with mock.patch("os.listdir", side_effect=throw(Exception)):
-            self.assertRaises(
-                Exception,
-                lambda: LocalFileStorage(os.path.join(TEST_FOLDER, "baz")),
-            )
+            stor = LocalFileStorage(os.path.join(TEST_FOLDER, "baz"))
+            stor.close()
         with LocalFileStorage(os.path.join(TEST_FOLDER, "baz")) as stor:
             with mock.patch("os.listdir", side_effect=throw(Exception)):
-                stor._maintenance_routine(silent=True)
-                self.assertRaises(Exception, stor._maintenance_routine)
+                stor._maintenance_routine()
             with mock.patch("os.path.isdir", side_effect=throw(Exception)):
-                stor._maintenance_routine(silent=True)
-                self.assertRaises(Exception, stor._maintenance_routine)
+                stor._maintenance_routine()

--- a/azure_monitor/tests/test_storage.py
+++ b/azure_monitor/tests/test_storage.py
@@ -32,7 +32,7 @@ def throw(exc_type, *args, **kwargs):
 
     return func
 
-
+# pylint: disable=no-self-use
 class TestLocalFileBlob(unittest.TestCase):
     def test_delete(self):
         blob = LocalFileBlob(os.path.join(TEST_FOLDER, "foobar"))


### PR DESCRIPTION
Similar to [OpenCensus](https://github.com/census-instrumentation/opencensus-python/pull/903).

1. Silences all exceptions thrown in storage.py
2. Changes default storage_path to tmpdirectory + 'opentelemetry-python' + ikey
3. Adds a more descriptive warning on request timeout to AI endpoint