### PR TITLE
Implement proxies for Azure exporters

### DIFF
--- a/azure_monitor/CHANGELOG.md
+++ b/azure_monitor/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Implement proxies in exporter configuration
-- ([#92](https://github.com/microsoft/opentelemetry-azure-monitor-python/pull/92))
+- ([#101](https://github.com/microsoft/opentelemetry-azure-monitor-python/pull/101))
 - Remove dependency metrics from auto-collection
 - ([#92](https://github.com/microsoft/opentelemetry-azure-monitor-python/pull/92))
 

--- a/azure_monitor/CHANGELOG.md
+++ b/azure_monitor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Implement proxies in exporter configuration
+- ([#92](https://github.com/microsoft/opentelemetry-azure-monitor-python/pull/92))
 - Remove dependency metrics from auto-collection
 - ([#92](https://github.com/microsoft/opentelemetry-azure-monitor-python/pull/92))
 

--- a/azure_monitor/CHANGELOG.md
+++ b/azure_monitor/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## Unreleased
 
-- Implement proxies in exporter configuration
-- ([#101](https://github.com/microsoft/opentelemetry-azure-monitor-python/pull/101))
 - Remove dependency metrics from auto-collection
   ([#92](https://github.com/microsoft/opentelemetry-azure-monitor-python/pull/92))
 - Change default local storage directory
   ([#100](https://github.com/microsoft/opentelemetry-azure-monitor-python/pull/100))
+- Implement proxies in exporter configuration
+  ([#101](https://github.com/microsoft/opentelemetry-azure-monitor-python/pull/101))
 - Remove request failed per second metrics from auto-collection
   ([#102](https://github.com/microsoft/opentelemetry-azure-monitor-python/pull/102))
 

--- a/azure_monitor/examples/traces/server.py
+++ b/azure_monitor/examples/traces/server.py
@@ -3,7 +3,6 @@
 # pylint: disable=import-error
 # pylint: disable=no-member
 # pylint: disable=no-name-in-module
-import flask
 import requests
 from opentelemetry import trace
 from opentelemetry.ext.flask import FlaskInstrumentor
@@ -11,6 +10,7 @@ from opentelemetry.ext.requests import RequestsInstrumentor
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
 
+import flask
 from azure_monitor import AzureMonitorSpanExporter
 
 # The preferred tracer implementation must be set, as the opentelemetry-api

--- a/azure_monitor/examples/traces/server.py
+++ b/azure_monitor/examples/traces/server.py
@@ -3,6 +3,7 @@
 # pylint: disable=import-error
 # pylint: disable=no-member
 # pylint: disable=no-name-in-module
+import flask
 import requests
 from opentelemetry import trace
 from opentelemetry.ext.flask import FlaskInstrumentor
@@ -10,7 +11,6 @@ from opentelemetry.ext.requests import RequestsInstrumentor
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
 
-import flask
 from azure_monitor import AzureMonitorSpanExporter
 
 # The preferred tracer implementation must be set, as the opentelemetry-api

--- a/azure_monitor/setup.cfg
+++ b/azure_monitor/setup.cfg
@@ -28,8 +28,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    opentelemetry-api == 0.9b0
-    opentelemetry-sdk == 0.9b0
+    opentelemetry-api == 0.10b0
+    opentelemetry-sdk == 0.10b0
     psutil >= 5.6.3
     requests ~= 2.0
 

--- a/azure_monitor/src/azure_monitor/export/__init__.py
+++ b/azure_monitor/src/azure_monitor/export/__init__.py
@@ -122,7 +122,7 @@ class BaseExporter:
                         "Content-Type": "application/json; charset=utf-8",
                     },
                     timeout=self.options.timeout,
-                    proxies=json.loads(self.options.proxies),
+                    proxies=self.options.proxies,
                 )
             except requests.Timeout:
                 logger.warning(

--- a/azure_monitor/src/azure_monitor/export/__init__.py
+++ b/azure_monitor/src/azure_monitor/export/__init__.py
@@ -121,6 +121,7 @@ class BaseExporter:
                         "Content-Type": "application/json; charset=utf-8",
                     },
                     timeout=self.options.timeout,
+                    proxies=json.loads(self.options.proxies),
                 )
             except Exception as ex:
                 logger.warning("Transient client side error: %s.", ex)

--- a/azure_monitor/src/azure_monitor/options.py
+++ b/azure_monitor/src/azure_monitor/options.py
@@ -37,6 +37,7 @@ class ExporterOptions(BaseObject):
 
     __slots__ = (
         "connection_string",
+        "endpoint",
         "instrumentation_key",
         "proxies",
         "storage_maintenance_period",
@@ -109,8 +110,7 @@ class ExporterOptions(BaseObject):
 
         # proxies
         if self.proxies is None:
-            self.proxies = '{}'
-
+            self.proxies = "{}"
 
     def _validate_instrumentation_key(self) -> None:
         """Validates the instrumentation key used for Azure Monitor.

--- a/azure_monitor/src/azure_monitor/options.py
+++ b/azure_monitor/src/azure_monitor/options.py
@@ -27,6 +27,7 @@ class ExporterOptions(BaseObject):
     Args:
         connection_string: Azure Connection String.
         instrumentation_key: Azure Instrumentation Key.
+        proxies: Proxies to pass Azure Monitor request through.
         storage_maintenance_period: Local storage maintenance interval in seconds.
         storage_max_size: Local storage maximum size in bytes.
         storage_path: Local storage file path.
@@ -36,8 +37,8 @@ class ExporterOptions(BaseObject):
 
     __slots__ = (
         "connection_string",
-        "endpoint",
         "instrumentation_key",
+        "proxies",
         "storage_maintenance_period",
         "storage_max_size",
         "storage_path",
@@ -49,6 +50,7 @@ class ExporterOptions(BaseObject):
         self,
         connection_string: str = None,
         instrumentation_key: str = None,
+        proxies: typing.Dict[str, str] = None,
         storage_maintenance_period: int = 60,
         storage_max_size: int = 50 * 1024 * 1024,
         storage_path: str = None,
@@ -64,6 +66,7 @@ class ExporterOptions(BaseObject):
             )
         self.connection_string = connection_string
         self.instrumentation_key = instrumentation_key
+        self.proxies = proxies
         self.storage_maintenance_period = storage_maintenance_period
         self.storage_max_size = storage_max_size
         self.storage_path = storage_path
@@ -74,6 +77,7 @@ class ExporterOptions(BaseObject):
         self._validate_instrumentation_key()
 
     def _initialize(self) -> None:
+        # connection string and ikey
         code_cs = parse_connection_string(self.connection_string)
         code_ikey = self.instrumentation_key
         env_cs = parse_connection_string(
@@ -102,6 +106,11 @@ class ExporterOptions(BaseObject):
             or "https://dc.services.visualstudio.com"
         )
         self.endpoint = endpoint + "/v2/track"
+
+        # proxies
+        if self.proxies is None:
+            self.proxies = '{}'
+
 
     def _validate_instrumentation_key(self) -> None:
         """Validates the instrumentation key used for Azure Monitor.

--- a/azure_monitor/tests/auto_collection/live_metrics/test_exporter.py
+++ b/azure_monitor/tests/auto_collection/live_metrics/test_exporter.py
@@ -14,7 +14,7 @@ from opentelemetry.sdk.metrics import (
 )
 from opentelemetry.sdk.metrics.export import MetricRecord, MetricsExportResult
 from opentelemetry.sdk.metrics.export.aggregate import (
-    CounterAggregator,
+    SumAggregator,
     MinMaxSumCountAggregator,
     ValueObserverAggregator,
 )
@@ -79,7 +79,7 @@ class TestLiveMetricsExporter(unittest.TestCase):
     def test_export(self):
         """Test export."""
         record = MetricRecord(
-            self._test_metric, self._test_labels, CounterAggregator()
+            self._test_metric, self._test_labels, SumAggregator()
         )
         exporter = LiveMetricsExporter(
             instrumentation_key=self._instrumentation_key,
@@ -96,7 +96,7 @@ class TestLiveMetricsExporter(unittest.TestCase):
 
     def test_export_failed(self):
         record = MetricRecord(
-            self._test_metric, self._test_labels, CounterAggregator()
+            self._test_metric, self._test_labels, SumAggregator()
         )
         exporter = LiveMetricsExporter(
             instrumentation_key=self._instrumentation_key,
@@ -113,7 +113,7 @@ class TestLiveMetricsExporter(unittest.TestCase):
 
     def test_export_exception(self):
         record = MetricRecord(
-            self._test_metric, self._test_labels, CounterAggregator()
+            self._test_metric, self._test_labels, SumAggregator()
         )
         exporter = LiveMetricsExporter(
             instrumentation_key=self._instrumentation_key,
@@ -148,7 +148,7 @@ class TestLiveMetricsExporter(unittest.TestCase):
         self.assertEqual(envelope.metrics[0].weight, 1)
 
     def test_live_metric_envelope_counter(self):
-        aggregator = CounterAggregator()
+        aggregator = SumAggregator()
         aggregator.update(123)
         aggregator.take_checkpoint()
         record = MetricRecord(self._test_metric, self._test_labels, aggregator)
@@ -184,7 +184,7 @@ class TestLiveMetricsExporter(unittest.TestCase):
         self.assertEqual(envelope.metrics[0].weight, 1)
 
     def test_live_metric_envelope_documents(self):
-        aggregator = CounterAggregator()
+        aggregator = SumAggregator()
         aggregator.update(123)
         aggregator.take_checkpoint()
         record = MetricRecord(self._test_metric, self._test_labels, aggregator)

--- a/azure_monitor/tests/auto_collection/live_metrics/test_exporter.py
+++ b/azure_monitor/tests/auto_collection/live_metrics/test_exporter.py
@@ -14,8 +14,8 @@ from opentelemetry.sdk.metrics import (
 )
 from opentelemetry.sdk.metrics.export import MetricRecord, MetricsExportResult
 from opentelemetry.sdk.metrics.export.aggregate import (
-    SumAggregator,
     MinMaxSumCountAggregator,
+    SumAggregator,
     ValueObserverAggregator,
 )
 

--- a/azure_monitor/tests/metrics/test_metrics.py
+++ b/azure_monitor/tests/metrics/test_metrics.py
@@ -14,8 +14,8 @@ from opentelemetry.sdk.metrics import (
 )
 from opentelemetry.sdk.metrics.export import MetricRecord, MetricsExportResult
 from opentelemetry.sdk.metrics.export.aggregate import (
-    SumAggregator,
     MinMaxSumCountAggregator,
+    SumAggregator,
     ValueObserverAggregator,
 )
 from opentelemetry.sdk.util import ns_to_iso_str

--- a/azure_monitor/tests/metrics/test_metrics.py
+++ b/azure_monitor/tests/metrics/test_metrics.py
@@ -14,7 +14,7 @@ from opentelemetry.sdk.metrics import (
 )
 from opentelemetry.sdk.metrics.export import MetricRecord, MetricsExportResult
 from opentelemetry.sdk.metrics.export.aggregate import (
-    CounterAggregator,
+    SumAggregator,
     MinMaxSumCountAggregator,
     ValueObserverAggregator,
 )
@@ -109,7 +109,7 @@ class TestAzureMetricsExporter(unittest.TestCase):
     )
     def test_export(self, mte, transmit):
         record = MetricRecord(
-            CounterAggregator(), self._test_labels, self._test_metric
+            SumAggregator(), self._test_labels, self._test_metric
         )
         exporter = self._exporter
         mte.return_value = Envelope()
@@ -125,7 +125,7 @@ class TestAzureMetricsExporter(unittest.TestCase):
     )
     def test_export_failed_retryable(self, mte, transmit):
         record = MetricRecord(
-            CounterAggregator(), self._test_labels, self._test_metric
+            SumAggregator(), self._test_labels, self._test_metric
         )
         exporter = self._exporter
         transmit.return_value = ExportResult.FAILED_RETRYABLE
@@ -145,7 +145,7 @@ class TestAzureMetricsExporter(unittest.TestCase):
     )
     def test_export_exception(self, mte, transmit, logger_mock):
         record = MetricRecord(
-            CounterAggregator(), self._test_labels, self._test_metric
+            SumAggregator(), self._test_labels, self._test_metric
         )
         exporter = self._exporter
         mte.return_value = Envelope()
@@ -159,7 +159,7 @@ class TestAzureMetricsExporter(unittest.TestCase):
         self.assertIsNone(exporter._metric_to_envelope(None))
 
     def test_metric_to_envelope(self):
-        aggregator = CounterAggregator()
+        aggregator = SumAggregator()
         aggregator.update(123)
         aggregator.take_checkpoint()
         record = MetricRecord(self._test_metric, self._test_labels, aggregator)

--- a/azure_monitor/tests/test_base_exporter.py
+++ b/azure_monitor/tests/test_base_exporter.py
@@ -67,7 +67,7 @@ class TestBaseExporter(unittest.TestCase):
         """Test the constructor."""
         base = BaseExporter(
             instrumentation_key="4321abcd-5678-4efa-8abc-1234567890ab",
-            proxies='{"https":"https://test-proxy.com"}',
+            proxies={"https":"https://test-proxy.com"},
             storage_maintenance_period=2,
             storage_max_size=3,
             storage_path=os.path.join(TEST_FOLDER, self.id()),
@@ -80,7 +80,7 @@ class TestBaseExporter(unittest.TestCase):
             "4321abcd-5678-4efa-8abc-1234567890ab",
         )
         self.assertEqual(
-            base.options.proxies, '{"https":"https://test-proxy.com"}',
+            base.options.proxies, {"https":"https://test-proxy.com"},
         )
         self.assertEqual(base.options.storage_maintenance_period, 2)
         self.assertEqual(base.options.storage_max_size, 3)

--- a/azure_monitor/tests/test_base_exporter.py
+++ b/azure_monitor/tests/test_base_exporter.py
@@ -79,8 +79,7 @@ class TestBaseExporter(unittest.TestCase):
             "4321abcd-5678-4efa-8abc-1234567890ab",
         )
         self.assertEqual(
-            base.options.proxies,
-            '{"https":"https://test-proxy.com"}',
+            base.options.proxies, '{"https":"https://test-proxy.com"}',
         )
         self.assertEqual(base.options.storage_maintenance_period, 2)
         self.assertEqual(base.options.storage_max_size, 3)

--- a/azure_monitor/tests/test_base_exporter.py
+++ b/azure_monitor/tests/test_base_exporter.py
@@ -67,7 +67,7 @@ class TestBaseExporter(unittest.TestCase):
         """Test the constructor."""
         base = BaseExporter(
             instrumentation_key="4321abcd-5678-4efa-8abc-1234567890ab",
-            proxies={"https":"https://test-proxy.com"},
+            proxies={"https": "https://test-proxy.com"},
             storage_maintenance_period=2,
             storage_max_size=3,
             storage_path=os.path.join(TEST_FOLDER, self.id()),
@@ -80,7 +80,7 @@ class TestBaseExporter(unittest.TestCase):
             "4321abcd-5678-4efa-8abc-1234567890ab",
         )
         self.assertEqual(
-            base.options.proxies, {"https":"https://test-proxy.com"},
+            base.options.proxies, {"https": "https://test-proxy.com"},
         )
         self.assertEqual(base.options.storage_maintenance_period, 2)
         self.assertEqual(base.options.storage_max_size, 3)

--- a/azure_monitor/tests/test_base_exporter.py
+++ b/azure_monitor/tests/test_base_exporter.py
@@ -66,6 +66,7 @@ class TestBaseExporter(unittest.TestCase):
         """Test the constructor."""
         base = BaseExporter(
             instrumentation_key="4321abcd-5678-4efa-8abc-1234567890ab",
+            proxies='{"https":"https://test-proxy.com"}',
             storage_maintenance_period=2,
             storage_max_size=3,
             storage_path=os.path.join(TEST_FOLDER, self.id()),
@@ -76,6 +77,10 @@ class TestBaseExporter(unittest.TestCase):
         self.assertEqual(
             base.options.instrumentation_key,
             "4321abcd-5678-4efa-8abc-1234567890ab",
+        )
+        self.assertEqual(
+            base.options.proxies,
+            '{"https":"https://test-proxy.com"}',
         )
         self.assertEqual(base.options.storage_maintenance_period, 2)
         self.assertEqual(base.options.storage_max_size, 3)

--- a/azure_monitor/tests/test_options.py
+++ b/azure_monitor/tests/test_options.py
@@ -245,18 +245,18 @@ class TestOptions(unittest.TestCase):
         options = ExporterOptions(
             connection_string=None,
             instrumentation_key=self._valid_instrumentation_key,
-            proxies="{}",
+            proxies={},
         )
-        self.assertEqual(options.proxies, "{}")
+        self.assertEqual(options.proxies, {})
 
     def test_process_options_proxies_set_proxies(self):
         options = ExporterOptions(
             connection_string=None,
             instrumentation_key=self._valid_instrumentation_key,
-            proxies='{"https": "https://test-proxy.com"}',
+            proxies={"https": "https://test-proxy.com"},
         )
         self.assertEqual(
-            options.proxies, '{"https": "https://test-proxy.com"}'
+            options.proxies, {"https": "https://test-proxy.com"}
         )
 
     def test_parse_connection_string_invalid(self):

--- a/azure_monitor/tests/test_options.py
+++ b/azure_monitor/tests/test_options.py
@@ -242,18 +242,19 @@ class TestOptions(unittest.TestCase):
         )
 
     def test_process_options_proxies_default(self):
-        options = ExporterOptions()
-        options.proxies = "{}"
-        common.process_options(options)
-
+        options = ExporterOptions(
+            connection_string=None,
+            instrumentation_key=self._valid_instrumentation_key,
+            proxies='{}'
+        )
         self.assertEqual(options.proxies, "{}")
 
     def test_process_options_proxies_set_proxies(self):
-        options = ExporterOptions()
-        options.connection_string = None
-        options.proxies = '{"https": "https://test-proxy.com"}'
-        common.process_options(options)
-
+        options = ExporterOptions(
+            connection_string=None,
+            instrumentation_key=self._valid_instrumentation_key,
+            proxies='{"https": "https://test-proxy.com"}'
+        )
         self.assertEqual(
             options.proxies, '{"https": "https://test-proxy.com"}'
         )

--- a/azure_monitor/tests/test_options.py
+++ b/azure_monitor/tests/test_options.py
@@ -255,9 +255,7 @@ class TestOptions(unittest.TestCase):
             instrumentation_key=self._valid_instrumentation_key,
             proxies={"https": "https://test-proxy.com"},
         )
-        self.assertEqual(
-            options.proxies, {"https": "https://test-proxy.com"}
-        )
+        self.assertEqual(options.proxies, {"https": "https://test-proxy.com"})
 
     def test_parse_connection_string_invalid(self):
         self.assertRaises(

--- a/azure_monitor/tests/test_options.py
+++ b/azure_monitor/tests/test_options.py
@@ -255,8 +255,7 @@ class TestOptions(unittest.TestCase):
         common.process_options(options)
 
         self.assertEqual(
-            options.proxies,
-            '{"https": "https://test-proxy.com"}'
+            options.proxies, '{"https": "https://test-proxy.com"}'
         )
 
     def test_parse_connection_string_invalid(self):

--- a/azure_monitor/tests/test_options.py
+++ b/azure_monitor/tests/test_options.py
@@ -245,7 +245,7 @@ class TestOptions(unittest.TestCase):
         options = ExporterOptions(
             connection_string=None,
             instrumentation_key=self._valid_instrumentation_key,
-            proxies='{}'
+            proxies="{}",
         )
         self.assertEqual(options.proxies, "{}")
 
@@ -253,7 +253,7 @@ class TestOptions(unittest.TestCase):
         options = ExporterOptions(
             connection_string=None,
             instrumentation_key=self._valid_instrumentation_key,
-            proxies='{"https": "https://test-proxy.com"}'
+            proxies='{"https": "https://test-proxy.com"}',
         )
         self.assertEqual(
             options.proxies, '{"https": "https://test-proxy.com"}'

--- a/azure_monitor/tests/test_options.py
+++ b/azure_monitor/tests/test_options.py
@@ -241,6 +241,24 @@ class TestOptions(unittest.TestCase):
             options.endpoint, "https://dc.services.visualstudio.com/v2/track"
         )
 
+    def test_process_options_proxies_default(self):
+        options = ExporterOptions()
+        options.proxies = "{}"
+        common.process_options(options)
+
+        self.assertEqual(options.proxies, "{}")
+
+    def test_process_options_proxies_set_proxies(self):
+        options = ExporterOptions()
+        options.connection_string = None
+        options.proxies = '{"https": "https://test-proxy.com"}'
+        common.process_options(options)
+
+        self.assertEqual(
+            options.proxies,
+            '{"https": "https://test-proxy.com"}'
+        )
+
     def test_parse_connection_string_invalid(self):
         self.assertRaises(
             ValueError, lambda: ExporterOptions(connection_string="asd")


### PR DESCRIPTION
Add the ability to specify proxies that the request to Azure Monitor backend will pass through.

Users will pass in a string representing a dict format.

See [requests](https://requests.readthedocs.io/en/master/user/advanced/#proxies) for more details.