### PR TITLE
Change epoch for live metrics

### DIFF
--- a/azure_monitor/CHANGELOG.md
+++ b/azure_monitor/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Change epoch for live metrics
+  ([#115](https://github.com/microsoft/opentelemetry-azure-monitor-python/pull/115))
+
 ## 0.4b.0
 Released 2020-06-29
 

--- a/azure_monitor/examples/metrics/observer.py
+++ b/azure_monitor/examples/metrics/observer.py
@@ -48,4 +48,4 @@ meter.register_observer(
     label_keys=(),
 )
 
-input("Metrics will be printed soon. Press a key to finish...\n")
+input("Press any key to exit...")

--- a/azure_monitor/src/azure_monitor/sdk/auto_collection/live_metrics/sender.py
+++ b/azure_monitor/src/azure_monitor/sdk/auto_collection/live_metrics/sender.py
@@ -3,7 +3,6 @@
 #
 import json
 import logging
-import time
 
 import requests
 
@@ -42,7 +41,7 @@ class LiveMetricsSender:
                     "Expect": "100-continue",
                     "Content-Type": "application/json; charset=utf-8",
                     utils.LIVE_METRICS_TRANSMISSION_TIME_HEADER: str(
-                        round(time.time()) * 1000
+                        utils.get_time_since_epoch()
                     ),
                 },
             )

--- a/azure_monitor/src/azure_monitor/sdk/auto_collection/live_metrics/utils.py
+++ b/azure_monitor/src/azure_monitor/sdk/auto_collection/live_metrics/utils.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 #
 import datetime
+import time
 import uuid
 
 from azure_monitor.protocol import LiveMetricEnvelope
@@ -22,7 +23,7 @@ def create_metric_envelope(instrumentation_key: str):
         machine_name=azure_monitor_context.get("ai.device.id"),
         metrics=None,
         stream_id=STREAM_ID,
-        timestamp="/Date({0})/".format(str(get_time_since_epoch())),
+        timestamp="/Date({0})/".format(str(int(time.time()) * 1000)),
         version=azure_monitor_context.get("ai.internal.sdkVersion"),
     )
     return envelope

--- a/azure_monitor/src/azure_monitor/sdk/auto_collection/live_metrics/utils.py
+++ b/azure_monitor/src/azure_monitor/sdk/auto_collection/live_metrics/utils.py
@@ -31,8 +31,8 @@ def create_metric_envelope(instrumentation_key: str):
 def get_time_since_epoch():
     now = datetime.datetime.now()
     # epoch is defined as 12:00:00 midnight on January 1, 0001 for Microsoft
-    epoch = datetime.datetime(1,1,1)
+    epoch = datetime.datetime(1, 1, 1)
     delta = (now - epoch).total_seconds()
-    # return the number of 100-nanosecond intervals 
+    # return the number of 100-nanosecond intervals
     delta = round(delta * 10000000)
     return delta

--- a/azure_monitor/src/azure_monitor/sdk/auto_collection/live_metrics/utils.py
+++ b/azure_monitor/src/azure_monitor/sdk/auto_collection/live_metrics/utils.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 #
-import time
+import datetime
 import uuid
 
 from azure_monitor.protocol import LiveMetricEnvelope
@@ -22,7 +22,17 @@ def create_metric_envelope(instrumentation_key: str):
         machine_name=azure_monitor_context.get("ai.device.id"),
         metrics=None,
         stream_id=STREAM_ID,
-        timestamp="/Date({0})/".format(str(int(time.time()) * 1000)),
+        timestamp="/Date({0})/".format(str(get_time_since_epoch())),
         version=azure_monitor_context.get("ai.internal.sdkVersion"),
     )
     return envelope
+
+
+def get_time_since_epoch():
+    now = datetime.datetime.now()
+    # epoch is defined as 12:00:00 midnight on January 1, 0001 for Microsoft
+    epoch = datetime.datetime(1,1,1)
+    delta = (now - epoch).total_seconds()
+    # return the number of 100-nanosecond intervals 
+    delta = round(delta * 10000000)
+    return delta


### PR DESCRIPTION
Addresses https://github.com/microsoft/opentelemetry-azure-monitor-python/issues/112

`datetime.now()` will return the current local time as a `datetime` object.
`datetime.datetime(1, 1, 1)` will return a `datetime` object corresponding to 12:00:00 midnight on January 1, 0001

