### PR TITLE
Implement standard metrics for http dependency telemetry

### DIFF
--- a/azure_monitor/CHANGELOG.md
+++ b/azure_monitor/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Remove request metrics from auto-collection
   ([#124](https://github.com/microsoft/opentelemetry-azure-monitor-python/pull/124))
+- Implement standard metrics for requests library
+  ([#124](https://github.com/microsoft/opentelemetry-azure-monitor-python/pull/124))
 
 ## 0.5b.0
 Released 2020-09-24

--- a/azure_monitor/CHANGELOG.md
+++ b/azure_monitor/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - Remove request metrics from auto-collection
   ([#124](https://github.com/microsoft/opentelemetry-azure-monitor-python/pull/124))
-- Implement standard metrics for requests library
-  ([#124](https://github.com/microsoft/opentelemetry-azure-monitor-python/pull/124))
+- Implement standard metrics for http dependency telemetry
+  ([#125](https://github.com/microsoft/opentelemetry-azure-monitor-python/pull/125))
 
 ## 0.5b.0
 Released 2020-09-24

--- a/azure_monitor/examples/metrics/standard.py
+++ b/azure_monitor/examples/metrics/standard.py
@@ -1,0 +1,30 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+import requests
+import time
+
+from opentelemetry import metrics
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
+from opentelemetry.sdk.metrics import MeterProvider
+
+from azure_monitor import AzureMonitorMetricsExporter
+
+# Use the default sdk implementation
+metrics.set_meter_provider(MeterProvider(stateful=False))
+
+# Track telemetry from the requests library
+RequestsInstrumentor().instrument()
+meter = RequestsInstrumentor().meter
+exporter = AzureMonitorMetricsExporter(
+    connection_string="InstrumentationKey=<INSTRUMENTATION KEY HERE>"
+)
+# Export standard metrics from requests library to Azure Monitor
+metrics.get_meter_provider().start_pipeline(meter, exporter, 5)
+
+for x in range(10):
+    for y in range(10):
+        requests.get("http://example.com")
+        time.sleep(2)
+    time.sleep(5)
+
+input("Press any key to exit...")

--- a/azure_monitor/examples/metrics/standard.py
+++ b/azure_monitor/examples/metrics/standard.py
@@ -1,5 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+# pylint: disable=import-error
+# pylint: disable=no-member
+# pylint: disable=no-name-in-module
 import time
 
 import requests

--- a/azure_monitor/examples/metrics/standard.py
+++ b/azure_monitor/examples/metrics/standard.py
@@ -1,8 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-import requests
 import time
 
+import requests
 from opentelemetry import metrics
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
 from opentelemetry.sdk.metrics import MeterProvider

--- a/azure_monitor/src/azure_monitor/export/metrics/__init__.py
+++ b/azure_monitor/src/azure_monitor/export/metrics/__init__.py
@@ -116,7 +116,7 @@ class AzureMonitorMetricsExporter(BaseExporter, MetricsExporter):
 
 def standard_metrics_processor(envelope):
     data = envelope.data.base_data
-    if len(data.metrics):
+    if data.metrics:
         properties = {}
         point = data.metrics[0]
         if point.name == "http.client.duration":

--- a/azure_monitor/src/azure_monitor/export/metrics/__init__.py
+++ b/azure_monitor/src/azure_monitor/export/metrics/__init__.py
@@ -37,6 +37,7 @@ class AzureMonitorMetricsExporter(BaseExporter, MetricsExporter):
     Args:
         options: :doc:`export.options` to allow configuration for the exporter
     """
+
     def __init__(self, **options):
         super().__init__(**options)
         self.add_telemetry_processor(standard_metrics_processor)
@@ -123,8 +124,12 @@ def standard_metrics_processor(envelope):
             point.kind = protocol.DataPointType.AGGREGATION.value
             properties["_MS.MetricId"] = "dependencies/duration"
             properties["_MS.IsAutocollected"] = "True"
-            properties["cloud/roleInstance"] = utils.azure_monitor_context.get("ai.cloud.roleInstance")
-            properties["cloud/roleName"] = utils.azure_monitor_context.get("ai.cloud.role")
+            properties["cloud/roleInstance"] = utils.azure_monitor_context.get(
+                "ai.cloud.roleInstance"
+            )
+            properties["cloud/roleName"] = utils.azure_monitor_context.get(
+                "ai.cloud.role"
+            )
             properties["Dependency.Success"] = "False"
             if data.properties.get("http.status_code"):
                 try:
@@ -136,7 +141,9 @@ def standard_metrics_processor(envelope):
             # TODO: Check other properties if url doesn't exist
             properties["dependency/target"] = data.properties.get("http.url")
             properties["Dependency.Type"] = "HTTP"
-            properties["dependency/resultCode"] = data.properties.get("http.status_code")
+            properties["dependency/resultCode"] = data.properties.get(
+                "http.status_code"
+            )
             # Won't need this once Azure Monitor supports histograms
             # We can't actually get the individual buckets because the bucket
             # collection must happen on the SDK side

--- a/azure_monitor/src/azure_monitor/export/metrics/__init__.py
+++ b/azure_monitor/src/azure_monitor/export/metrics/__init__.py
@@ -37,6 +37,9 @@ class AzureMonitorMetricsExporter(BaseExporter, MetricsExporter):
     Args:
         options: :doc:`export.options` to allow configuration for the exporter
     """
+    def __init__(self, **options):
+        super().__init__(**options)
+        self.add_telemetry_processor(standard_metrics_processor)
 
     def export(
         self, metric_records: Sequence[MetricRecord]
@@ -73,13 +76,19 @@ class AzureMonitorMetricsExporter(BaseExporter, MetricsExporter):
         )
         envelope.name = "Microsoft.ApplicationInsights.Metric"
         value = 0
+        _min = None
+        _max = None
+        count = None
         metric = metric_record.instrument
         if isinstance(metric, ValueObserver):
             # mmscl
             value = metric_record.aggregator.checkpoint.last
         elif isinstance(metric, ValueRecorder):
             # mmsc
-            value = metric_record.aggregator.checkpoint.count
+            value = metric_record.aggregator.checkpoint.sum
+            _min = metric_record.aggregator.checkpoint.min
+            _max = metric_record.aggregator.checkpoint.max
+            count = metric_record.aggregator.checkpoint.count
         else:
             # sum or lv
             value = metric_record.aggregator.checkpoint
@@ -90,6 +99,9 @@ class AzureMonitorMetricsExporter(BaseExporter, MetricsExporter):
             ns=metric.description,
             name=metric.name,
             value=value,
+            min=_min,
+            max=_max,
+            count=count,
             kind=protocol.DataPointType.MEASUREMENT.value,
         )
 
@@ -99,3 +111,37 @@ class AzureMonitorMetricsExporter(BaseExporter, MetricsExporter):
         data = protocol.MetricData(metrics=[data_point], properties=properties)
         envelope.data = protocol.Data(base_data=data, base_type="MetricData")
         return envelope
+
+
+def standard_metrics_processor(envelope):
+    data = envelope.data.base_data
+    if len(data.metrics):
+        properties = {}
+        point = data.metrics[0]
+        if point.name == "http.client.duration":
+            point.name = "Dependency duration"
+            point.kind = protocol.DataPointType.AGGREGATION.value
+            properties["_MS.MetricId"] = "dependencies/duration"
+            properties["_MS.IsAutocollected"] = "True"
+            properties["cloud/roleInstance"] = utils.azure_monitor_context.get("ai.cloud.roleInstance")
+            properties["cloud/roleName"] = utils.azure_monitor_context.get("ai.cloud.role")
+            properties["Dependency.Success"] = "False"
+            if data.properties.get("http.status_code"):
+                try:
+                    code = int(data.properties.get("http.status_code"))
+                    if 200 <= code < 400:
+                        properties["Dependency.Success"] = "True"
+                except ValueError:
+                    pass
+            # TODO: Check other properties if url doesn't exist
+            properties["dependency/target"] = data.properties.get("http.url")
+            properties["Dependency.Type"] = "HTTP"
+            properties["dependency/resultCode"] = data.properties.get("http.status_code")
+            # Won't need this once Azure Monitor supports histograms
+            # We can't actually get the individual buckets because the bucket
+            # collection must happen on the SDK side
+            properties["dependency/performanceBucket"] = ""
+            # TODO: OT does not have this in semantic conventions for trace
+            properties["operation/synthetic"] = ""
+        # TODO: Add other std. metrics as implemented
+        data.properties = properties

--- a/azure_monitor/tests/metrics/test_metrics.py
+++ b/azure_monitor/tests/metrics/test_metrics.py
@@ -170,22 +170,33 @@ class TestAzureMetricsExporter(unittest.TestCase):
         point.name = "http.client.duration"
         base_data = mock.Mock()
         base_data.metrics = [point]
-        base_data.properties = {"http.status_code":"200", "http.url":"http://example.com"}
+        base_data.properties = {
+            "http.status_code": "200",
+            "http.url": "http://example.com",
+        }
         envelope.data.base_data = base_data
         standard_metrics_processor(envelope)
         self.assertEqual(point.name, "Dependency duration")
         self.assertEqual(point.kind, DataPointType.AGGREGATION.value)
-        self.assertEqual(base_data.properties["_MS.MetricId"], "dependencies/duration")
+        self.assertEqual(
+            base_data.properties["_MS.MetricId"], "dependencies/duration"
+        )
         self.assertEqual(base_data.properties["_MS.IsAutocollected"], "True")
         role_instance = azure_monitor_context.get("ai.cloud.roleInstance")
         role_name = azure_monitor_context.get("ai.cloud.role")
-        self.assertEqual(base_data.properties["cloud/roleInstance"], role_instance)
+        self.assertEqual(
+            base_data.properties["cloud/roleInstance"], role_instance
+        )
         self.assertEqual(base_data.properties["cloud/roleName"], role_name)
         self.assertEqual(base_data.properties["Dependency.Success"], "True")
-        self.assertEqual(base_data.properties["dependency/target"], "http://example.com")
+        self.assertEqual(
+            base_data.properties["dependency/target"], "http://example.com"
+        )
         self.assertEqual(base_data.properties["Dependency.Type"], "HTTP")
         self.assertEqual(base_data.properties["dependency/resultCode"], "200")
-        self.assertEqual(base_data.properties["dependency/performanceBucket"], "")
+        self.assertEqual(
+            base_data.properties["dependency/performanceBucket"], ""
+        )
         self.assertEqual(base_data.properties["operation/synthetic"], "")
         base_data.properties["http.status_code"] = "500"
         point.name = "http.client.duration"


### PR DESCRIPTION
Part of https://github.com/microsoft/opentelemetry-azure-monitor-python/issues/123

Adds the custom properties to a telemetry processor that runs every time a http dependency telemetry is exported.
Implementation taken from the App Insights [Dot net](https://github.com/microsoft/ApplicationInsights-dotnet/blob/b91ff5741ca543cc9babc4f2b169600a3a8b9a06/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/MetricTerms.cs#L89) SDK.